### PR TITLE
riscv64: Add gdbserver support

### DIFF
--- a/VEX/priv/guest_riscv64_toIR.c
+++ b/VEX/priv/guest_riscv64_toIR.c
@@ -1625,6 +1625,15 @@ static Bool dis_RV64I(/*MB_OUT*/ DisResult* dres,
       return True;
    }
 
+   /* ------------------------ ebreak ------------------------ */
+   if (INSN(31, 0) == 0b00000000000100000000000001110011) {
+      putPC(irsb, mkU64(guest_pc_curr_instr + 4));
+      dres->whatNext    = Dis_StopHere;
+      dres->jk_StopHere = Ijk_SigTRAP;
+      DIP("ebreak\n");
+      return True;
+   }
+
    /* -------------- addiw rd, rs1, imm[11:0] --------------- */
    if (INSN(6, 0) == 0b0011011 && INSN(14, 12) == 0b000) {
       UInt rd      = INSN(11, 7);

--- a/coregrind/Makefile.am
+++ b/coregrind/Makefile.am
@@ -769,7 +769,15 @@ GDBSERVER_XML_FILES = \
 	m_gdbserver/mips64-linux-valgrind.xml \
 	m_gdbserver/mips64-fpu-valgrind-s1.xml \
 	m_gdbserver/mips64-fpu-valgrind-s2.xml \
-	m_gdbserver/mips64-fpu.xml
+	m_gdbserver/mips64-fpu.xml \
+	m_gdbserver/riscv64-cpu-valgrind-s1.xml \
+	m_gdbserver/riscv64-cpu-valgrind-s2.xml \
+	m_gdbserver/riscv64-cpu.xml \
+	m_gdbserver/riscv64-linux.xml \
+	m_gdbserver/riscv64-linux-valgrind.xml \
+	m_gdbserver/riscv64-fpu-valgrind-s1.xml \
+	m_gdbserver/riscv64-fpu-valgrind-s2.xml \
+	m_gdbserver/riscv64-fpu.xml
 
 # so as to make sure these get copied into the install tree
 vglibdir = $(pkglibexecdir)

--- a/coregrind/m_gdbserver/riscv64-cpu-valgrind-s1.xml
+++ b/coregrind/m_gdbserver/riscv64-cpu-valgrind-s1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.cpu.valgrind.s1">
+  <reg name="zeros1" bitsize="64" type="int" regnum="69"/>
+  <reg name="ras1" bitsize="64" type="int"/>
+  <reg name="sps1" bitsize="64" type="int"/>
+  <reg name="gps1" bitsize="64" type="int"/>
+  <reg name="tps1" bitsize="64" type="int"/>
+  <reg name="t0s1" bitsize="64" type="int"/>
+  <reg name="t1s1" bitsize="64" type="int"/>
+  <reg name="t2s1" bitsize="64" type="int"/>
+  <reg name="fps1" bitsize="64" type="int"/>
+  <reg name="s1s1" bitsize="64" type="int"/>
+  <reg name="a0s1" bitsize="64" type="int"/>
+  <reg name="a1s1" bitsize="64" type="int"/>
+  <reg name="a2s1" bitsize="64" type="int"/>
+  <reg name="a3s1" bitsize="64" type="int"/>
+  <reg name="a4s1" bitsize="64" type="int"/>
+  <reg name="a5s1" bitsize="64" type="int"/>
+  <reg name="a6s1" bitsize="64" type="int"/>
+  <reg name="a7s1" bitsize="64" type="int"/>
+  <reg name="s2s1" bitsize="64" type="int"/>
+  <reg name="s3s1" bitsize="64" type="int"/>
+  <reg name="s4s1" bitsize="64" type="int"/>
+  <reg name="s5s1" bitsize="64" type="int"/>
+  <reg name="s6s1" bitsize="64" type="int"/>
+  <reg name="s7s1" bitsize="64" type="int"/>
+  <reg name="s8s1" bitsize="64" type="int"/>
+  <reg name="s9s1" bitsize="64" type="int"/>
+  <reg name="s10s1" bitsize="64" type="int"/>
+  <reg name="s11s1" bitsize="64" type="int"/>
+  <reg name="t3s1" bitsize="64" type="int"/>
+  <reg name="t4s1" bitsize="64" type="int"/>
+  <reg name="t5s1" bitsize="64" type="int"/>
+  <reg name="t6s1" bitsize="64" type="int"/>
+  <reg name="pcs1" bitsize="64" type="int"/>
+</feature>

--- a/coregrind/m_gdbserver/riscv64-cpu-valgrind-s2.xml
+++ b/coregrind/m_gdbserver/riscv64-cpu-valgrind-s2.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.cpu.valgrind.s2">
+  <reg name="zeros2" bitsize="64" type="int" regnum="138"/>
+  <reg name="ras2" bitsize="64" type="int"/>
+  <reg name="sps2" bitsize="64" type="int"/>
+  <reg name="gps2" bitsize="64" type="int"/>
+  <reg name="tps2" bitsize="64" type="int"/>
+  <reg name="t0s2" bitsize="64" type="int"/>
+  <reg name="t1s2" bitsize="64" type="int"/>
+  <reg name="t2s2" bitsize="64" type="int"/>
+  <reg name="fps2" bitsize="64" type="int"/>
+  <reg name="s1s2" bitsize="64" type="int"/>
+  <reg name="a0s2" bitsize="64" type="int"/>
+  <reg name="a1s2" bitsize="64" type="int"/>
+  <reg name="a2s2" bitsize="64" type="int"/>
+  <reg name="a3s2" bitsize="64" type="int"/>
+  <reg name="a4s2" bitsize="64" type="int"/>
+  <reg name="a5s2" bitsize="64" type="int"/>
+  <reg name="a6s2" bitsize="64" type="int"/>
+  <reg name="a7s2" bitsize="64" type="int"/>
+  <reg name="s2s2" bitsize="64" type="int"/>
+  <reg name="s3s2" bitsize="64" type="int"/>
+  <reg name="s4s2" bitsize="64" type="int"/>
+  <reg name="s5s2" bitsize="64" type="int"/>
+  <reg name="s6s2" bitsize="64" type="int"/>
+  <reg name="s7s2" bitsize="64" type="int"/>
+  <reg name="s8s2" bitsize="64" type="int"/>
+  <reg name="s9s2" bitsize="64" type="int"/>
+  <reg name="s10s2" bitsize="64" type="int"/>
+  <reg name="s11s2" bitsize="64" type="int"/>
+  <reg name="t3s2" bitsize="64" type="int"/>
+  <reg name="t4s2" bitsize="64" type="int"/>
+  <reg name="t5s2" bitsize="64" type="int"/>
+  <reg name="t6s2" bitsize="64" type="int"/>
+  <reg name="pcs2" bitsize="64" type="int"/>
+</feature>

--- a/coregrind/m_gdbserver/riscv64-cpu.xml
+++ b/coregrind/m_gdbserver/riscv64-cpu.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.cpu">
+  <reg name="zero" bitsize="64" type="int" regnum="0"/>
+  <reg name="ra" bitsize="64" type="code_ptr"/>
+  <reg name="sp" bitsize="64" type="data_ptr"/>
+  <reg name="gp" bitsize="64" type="data_ptr"/>
+  <reg name="tp" bitsize="64" type="data_ptr"/>
+  <reg name="t0" bitsize="64" type="int"/>
+  <reg name="t1" bitsize="64" type="int"/>
+  <reg name="t2" bitsize="64" type="int"/>
+  <reg name="fp" bitsize="64" type="data_ptr"/>
+  <reg name="s1" bitsize="64" type="int"/>
+  <reg name="a0" bitsize="64" type="int"/>
+  <reg name="a1" bitsize="64" type="int"/>
+  <reg name="a2" bitsize="64" type="int"/>
+  <reg name="a3" bitsize="64" type="int"/>
+  <reg name="a4" bitsize="64" type="int"/>
+  <reg name="a5" bitsize="64" type="int"/>
+  <reg name="a6" bitsize="64" type="int"/>
+  <reg name="a7" bitsize="64" type="int"/>
+  <reg name="s2" bitsize="64" type="int"/>
+  <reg name="s3" bitsize="64" type="int"/>
+  <reg name="s4" bitsize="64" type="int"/>
+  <reg name="s5" bitsize="64" type="int"/>
+  <reg name="s6" bitsize="64" type="int"/>
+  <reg name="s7" bitsize="64" type="int"/>
+  <reg name="s8" bitsize="64" type="int"/>
+  <reg name="s9" bitsize="64" type="int"/>
+  <reg name="s10" bitsize="64" type="int"/>
+  <reg name="s11" bitsize="64" type="int"/>
+  <reg name="t3" bitsize="64" type="int"/>
+  <reg name="t4" bitsize="64" type="int"/>
+  <reg name="t5" bitsize="64" type="int"/>
+  <reg name="t6" bitsize="64" type="int"/>
+  <reg name="pc" bitsize="64" type="code_ptr"/>
+</feature>

--- a/coregrind/m_gdbserver/riscv64-fpu-valgrind-s1.xml
+++ b/coregrind/m_gdbserver/riscv64-fpu-valgrind-s1.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.fpu.valgrind.s1">
+
+  <reg name="ft0s1" bitsize="64" type="int" regnum="102"/>
+  <reg name="ft1s1" bitsize="64" type="int"/>
+  <reg name="ft2s1" bitsize="64" type="int"/>
+  <reg name="ft3s1" bitsize="64" type="int"/>
+  <reg name="ft4s1" bitsize="64" type="int"/>
+  <reg name="ft5s1" bitsize="64" type="int"/>
+  <reg name="ft6s1" bitsize="64" type="int"/>
+  <reg name="ft7s1" bitsize="64" type="int"/>
+  <reg name="fs0s1" bitsize="64" type="int"/>
+  <reg name="fs1s1" bitsize="64" type="int"/>
+  <reg name="fa0s1" bitsize="64" type="int"/>
+  <reg name="fa1s1" bitsize="64" type="int"/>
+  <reg name="fa2s1" bitsize="64" type="int"/>
+  <reg name="fa3s1" bitsize="64" type="int"/>
+  <reg name="fa4s1" bitsize="64" type="int"/>
+  <reg name="fa5s1" bitsize="64" type="int"/>
+  <reg name="fa6s1" bitsize="64" type="int"/>
+  <reg name="fa7s1" bitsize="64" type="int"/>
+  <reg name="fs2s1" bitsize="64" type="int"/>
+  <reg name="fs3s1" bitsize="64" type="int"/>
+  <reg name="fs4s1" bitsize="64" type="int"/>
+  <reg name="fs5s1" bitsize="64" type="int"/>
+  <reg name="fs6s1" bitsize="64" type="int"/>
+  <reg name="fs7s1" bitsize="64" type="int"/>
+  <reg name="fs8s1" bitsize="64" type="int"/>
+  <reg name="fs9s1" bitsize="64" type="int"/>
+  <reg name="fs10s1" bitsize="64" type="int"/>
+  <reg name="fs11s1" bitsize="64" type="int"/>
+  <reg name="ft8s1" bitsize="64" type="int"/>
+  <reg name="ft9s1" bitsize="64" type="int"/>
+  <reg name="ft10s1" bitsize="64" type="int"/>
+  <reg name="ft11s1" bitsize="64" type="int"/>
+
+  <reg name="fflagss1" bitsize="32" type="int" regnum="135"/>
+  <reg name="frms1" bitsize="32" type="int"/>
+  <reg name="fcsrs1" bitsize="32" type="int"/>
+</feature>

--- a/coregrind/m_gdbserver/riscv64-fpu-valgrind-s2.xml
+++ b/coregrind/m_gdbserver/riscv64-fpu-valgrind-s2.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.fpu.valgrind.s2">
+
+  <reg name="ft0s2" bitsize="64" type="int" regnum="171"/>
+  <reg name="ft1s2" bitsize="64" type="int"/>
+  <reg name="ft2s2" bitsize="64" type="int"/>
+  <reg name="ft3s2" bitsize="64" type="int"/>
+  <reg name="ft4s2" bitsize="64" type="int"/>
+  <reg name="ft5s2" bitsize="64" type="int"/>
+  <reg name="ft6s2" bitsize="64" type="int"/>
+  <reg name="ft7s2" bitsize="64" type="int"/>
+  <reg name="fs0s2" bitsize="64" type="int"/>
+  <reg name="fs1s2" bitsize="64" type="int"/>
+  <reg name="fa0s2" bitsize="64" type="int"/>
+  <reg name="fa1s2" bitsize="64" type="int"/>
+  <reg name="fa2s2" bitsize="64" type="int"/>
+  <reg name="fa3s2" bitsize="64" type="int"/>
+  <reg name="fa4s2" bitsize="64" type="int"/>
+  <reg name="fa5s2" bitsize="64" type="int"/>
+  <reg name="fa6s2" bitsize="64" type="int"/>
+  <reg name="fa7s2" bitsize="64" type="int"/>
+  <reg name="fs2s2" bitsize="64" type="int"/>
+  <reg name="fs3s2" bitsize="64" type="int"/>
+  <reg name="fs4s2" bitsize="64" type="int"/>
+  <reg name="fs5s2" bitsize="64" type="int"/>
+  <reg name="fs6s2" bitsize="64" type="int"/>
+  <reg name="fs7s2" bitsize="64" type="int"/>
+  <reg name="fs8s2" bitsize="64" type="int"/>
+  <reg name="fs9s2" bitsize="64" type="int"/>
+  <reg name="fs10s2" bitsize="64" type="int"/>
+  <reg name="fs11s2" bitsize="64" type="int"/>
+  <reg name="ft8s2" bitsize="64" type="int"/>
+  <reg name="ft9s2" bitsize="64" type="int"/>
+  <reg name="ft10s2" bitsize="64" type="int"/>
+  <reg name="ft11s2" bitsize="64" type="int"/>
+
+  <reg name="fflagss2" bitsize="32" type="int" regnum="204"/>
+  <reg name="frms2" bitsize="32" type="int"/>
+  <reg name="fcsrs2" bitsize="32" type="int"/>
+</feature>

--- a/coregrind/m_gdbserver/riscv64-fpu.xml
+++ b/coregrind/m_gdbserver/riscv64-fpu.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.fpu">
+
+  <union id="riscv_double">
+    <field name="float" type="ieee_single"/>
+    <field name="double" type="ieee_double"/>
+  </union>
+
+  <reg name="ft0" bitsize="64" type="riscv_double" regnum="33"/>
+  <reg name="ft1" bitsize="64" type="riscv_double"/>
+  <reg name="ft2" bitsize="64" type="riscv_double"/>
+  <reg name="ft3" bitsize="64" type="riscv_double"/>
+  <reg name="ft4" bitsize="64" type="riscv_double"/>
+  <reg name="ft5" bitsize="64" type="riscv_double"/>
+  <reg name="ft6" bitsize="64" type="riscv_double"/>
+  <reg name="ft7" bitsize="64" type="riscv_double"/>
+  <reg name="fs0" bitsize="64" type="riscv_double"/>
+  <reg name="fs1" bitsize="64" type="riscv_double"/>
+  <reg name="fa0" bitsize="64" type="riscv_double"/>
+  <reg name="fa1" bitsize="64" type="riscv_double"/>
+  <reg name="fa2" bitsize="64" type="riscv_double"/>
+  <reg name="fa3" bitsize="64" type="riscv_double"/>
+  <reg name="fa4" bitsize="64" type="riscv_double"/>
+  <reg name="fa5" bitsize="64" type="riscv_double"/>
+  <reg name="fa6" bitsize="64" type="riscv_double"/>
+  <reg name="fa7" bitsize="64" type="riscv_double"/>
+  <reg name="fs2" bitsize="64" type="riscv_double"/>
+  <reg name="fs3" bitsize="64" type="riscv_double"/>
+  <reg name="fs4" bitsize="64" type="riscv_double"/>
+  <reg name="fs5" bitsize="64" type="riscv_double"/>
+  <reg name="fs6" bitsize="64" type="riscv_double"/>
+  <reg name="fs7" bitsize="64" type="riscv_double"/>
+  <reg name="fs8" bitsize="64" type="riscv_double"/>
+  <reg name="fs9" bitsize="64" type="riscv_double"/>
+  <reg name="fs10" bitsize="64" type="riscv_double"/>
+  <reg name="fs11" bitsize="64" type="riscv_double"/>
+  <reg name="ft8" bitsize="64" type="riscv_double"/>
+  <reg name="ft9" bitsize="64" type="riscv_double"/>
+  <reg name="ft10" bitsize="64" type="riscv_double"/>
+  <reg name="ft11" bitsize="64" type="riscv_double"/>
+
+  <reg name="fflags" bitsize="32" type="int" regnum="66"/>
+  <reg name="frm" bitsize="32" type="int" regnum="67"/>
+  <reg name="fcsr" bitsize="32" type="int" regnum="68"/>
+</feature>

--- a/coregrind/m_gdbserver/riscv64-linux-valgrind.xml
+++ b/coregrind/m_gdbserver/riscv64-linux-valgrind.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE target SYSTEM "gdb-target.dtd">
+<target>
+  <architecture>riscv</architecture>
+  <xi:include href="riscv64-cpu.xml"/>
+  <xi:include href="riscv64-fpu.xml"/>
+  <xi:include href="riscv64-cpu-valgrind-s1.xml"/>
+  <xi:include href="riscv64-fpu-valgrind-s1.xml"/>
+  <xi:include href="riscv64-cpu-valgrind-s2.xml"/>
+  <xi:include href="riscv64-fpu-valgrind-s2.xml"/>
+
+  <feature name="org.gnu.gdb.riscv.linux">
+    <reg name="restart" bitsize="64" group="system"/>
+  </feature>
+</target>

--- a/coregrind/m_gdbserver/riscv64-linux.xml
+++ b/coregrind/m_gdbserver/riscv64-linux.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2022 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE target SYSTEM "gdb-target.dtd">
+<target>
+  <architecture>riscv</architecture>
+  <xi:include href="riscv64-cpu.xml"/>
+  <xi:include href="riscv64-fpu.xml"/>
+
+  <feature name="org.gnu.gdb.riscv.linux">
+    <reg name="restart" bitsize="64" group="system"/>
+  </feature>
+</target>

--- a/coregrind/m_gdbserver/target.c
+++ b/coregrind/m_gdbserver/target.c
@@ -903,8 +903,7 @@ void valgrind_initialize_target(void)
 #elif defined(VGA_nanomips)
    nanomips_init_architecture(&the_low_target);
 #elif defined(VGA_riscv64)
-   /* TODO Implement. */
-   /*I_die_here;*/
+   riscv64_init_architecture(&the_low_target);
 #else
    #error "architecture missing in target.c valgrind_initialize_target"
 #endif

--- a/coregrind/m_gdbserver/valgrind-low-riscv64.c
+++ b/coregrind/m_gdbserver/valgrind-low-riscv64.c
@@ -1,1 +1,292 @@
-/* TODO */
+/* Low level interface to valgrind, for the remote server for GDB integrated
+   in valgrind.
+   Copyright (C) 2022
+   Free Software Foundation, Inc.
+
+   This file is part of VALGRIND.
+   It has been inspired from a file from gdbserver in gdb 6.6.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
+
+#include "server.h"
+#include "target.h"
+#include "regdef.h"
+#include "regcache.h"
+
+#include "pub_core_machine.h"
+#include "pub_core_threadstate.h"
+#include "pub_core_transtab.h"
+#include "pub_core_gdbserver.h"
+#include "pub_core_debuginfo.h"
+
+#include "valgrind_low.h"
+
+#include "libvex_guest_riscv64.h"
+
+/* from GDB gdb/features/riscv/64bit-{cpu,fpu}.c */
+static struct reg regs[] = {
+  { "zero", 0, 64 },
+  { "ra", 64, 64 },
+  { "sp", 128, 64 },
+  { "gp", 192, 64 },
+  { "tp", 256, 64 },
+  { "t0", 320, 64 },
+  { "t1", 384, 64 },
+  { "t2", 448, 64 },
+  { "fp", 512, 64 },
+  { "s1", 576, 64 },
+  { "a0", 640, 64 },
+  { "a1", 704, 64 },
+  { "a2", 768, 64 },
+  { "a3", 832, 64 },
+  { "a4", 896, 64 },
+  { "a5", 960, 64 },
+  { "a6", 1024, 64 },
+  { "a7", 1088, 64 },
+  { "s2", 1152, 64 },
+  { "s3", 1216, 64 },
+  { "s4", 1280, 64 },
+  { "s5", 1344, 64 },
+  { "s6", 1408, 64 },
+  { "s7", 1472, 64 },
+  { "s8", 1536, 64 },
+  { "s9", 1600, 64 },
+  { "s10", 1664, 64 },
+  { "s11", 1728, 64 },
+  { "t3", 1792, 64 },
+  { "t4", 1856, 64 },
+  { "t5", 1920, 64 },
+  { "t6", 1984, 64 },
+  { "pc", 2048, 64 },
+
+  { "ft0", 2112, 64 },
+  { "ft1", 2176, 64 },
+  { "ft2", 2240, 64 },
+  { "ft3", 2304, 64 },
+  { "ft4", 2368, 64 },
+  { "ft5", 2432, 64 },
+  { "ft6", 2496, 64 },
+  { "ft7", 2560, 64 },
+  { "fs0", 2624, 64 },
+  { "fs1", 2688, 64 },
+  { "fa0", 2752, 64 },
+  { "fa1", 2816, 64 },
+  { "fa2", 2880, 64 },
+  { "fa3", 2944, 64 },
+  { "fa4", 3008, 64 },
+  { "fa5", 3072, 64 },
+  { "fa6", 3136, 64 },
+  { "fa7", 3200, 64 },
+  { "fs2", 3264, 64 },
+  { "fs3", 3328, 64 },
+  { "fs4", 3392, 64 },
+  { "fs5", 3456, 64 },
+  { "fs6", 3520, 64 },
+  { "fs7", 3584, 64 },
+  { "fs8", 3648, 64 },
+  { "fs9", 3712, 64 },
+  { "fs10", 3776, 64 },
+  { "fs11", 3840, 64 },
+  { "ft8", 3904, 64 },
+  { "ft9", 3968, 64 },
+  { "ft10", 4032, 64 },
+  { "ft11", 4096, 64 },
+  { "", 4160, 0 },  /* regnums have a hole here */
+  { "fflags", 4160, 32 },
+  { "frm", 4192, 32 },
+  { "fcsr", 4224, 32 },
+};
+
+/* from GDB gdbserver/linux-riscv-low.cc */
+static const char *expedite_regs[] = { "sp", "pc", 0 };
+
+#define num_regs (sizeof (regs) / sizeof (regs[0]))
+
+static
+CORE_ADDR get_pc (void)
+{
+   unsigned long pc;
+
+   collect_register_by_name ("pc", &pc);
+
+   dlog(1, "stop pc is %p\n", (void *) pc);
+   return pc;
+}
+
+static
+void set_pc (CORE_ADDR newpc)
+{
+   Bool mod;
+   supply_register_by_name ("pc", &newpc, &mod);
+   if (mod)
+      dlog(1, "set pc to %p\n", C2v (newpc));
+   else
+      dlog(1, "set pc not changed %p\n", C2v (newpc));
+}
+
+/* store registers in the guest state (gdbserver_to_valgrind)
+   or fetch register from the guest state (valgrind_to_gdbserver). */
+static
+void transfer_register (ThreadId tid, int abs_regno, void * buf,
+                        transfer_direction dir, int size, Bool *mod)
+{
+   ThreadState* tst = VG_(get_ThreadState)(tid);
+   int set = abs_regno / num_regs;
+   int regno = abs_regno % num_regs;
+   *mod = False;
+   UInt v, *p;
+
+   VexGuestRISCV64State* riscv = (VexGuestRISCV64State*) get_arch (set, tst);
+
+   switch (regno) {
+   // numbers here have to match the order of regs above
+   // Attention: gdb order does not match valgrind order.
+   case 0:  VG_(transfer) (&riscv->guest_x0,   buf, dir, size, mod); break;
+   case 1:  VG_(transfer) (&riscv->guest_x1,   buf, dir, size, mod); break;
+   case 2:  VG_(transfer) (&riscv->guest_x2,   buf, dir, size, mod); break;
+   case 3:  VG_(transfer) (&riscv->guest_x3,   buf, dir, size, mod); break;
+   case 4:  VG_(transfer) (&riscv->guest_x4,   buf, dir, size, mod); break;
+   case 5:  VG_(transfer) (&riscv->guest_x5,   buf, dir, size, mod); break;
+   case 6:  VG_(transfer) (&riscv->guest_x6,   buf, dir, size, mod); break;
+   case 7:  VG_(transfer) (&riscv->guest_x7,   buf, dir, size, mod); break;
+   case 8:  VG_(transfer) (&riscv->guest_x8,   buf, dir, size, mod); break;
+   case 9:  VG_(transfer) (&riscv->guest_x9,   buf, dir, size, mod); break;
+   case 10: VG_(transfer) (&riscv->guest_x10,  buf, dir, size, mod); break;
+   case 11: VG_(transfer) (&riscv->guest_x11,  buf, dir, size, mod); break;
+   case 12: VG_(transfer) (&riscv->guest_x12,  buf, dir, size, mod); break;
+   case 13: VG_(transfer) (&riscv->guest_x13,  buf, dir, size, mod); break;
+   case 14: VG_(transfer) (&riscv->guest_x14,  buf, dir, size, mod); break;
+   case 15: VG_(transfer) (&riscv->guest_x15,  buf, dir, size, mod); break;
+   case 16: VG_(transfer) (&riscv->guest_x16,  buf, dir, size, mod); break;
+   case 17: VG_(transfer) (&riscv->guest_x17,  buf, dir, size, mod); break;
+   case 18: VG_(transfer) (&riscv->guest_x18,  buf, dir, size, mod); break;
+   case 19: VG_(transfer) (&riscv->guest_x19,  buf, dir, size, mod); break;
+   case 20: VG_(transfer) (&riscv->guest_x20,  buf, dir, size, mod); break;
+   case 21: VG_(transfer) (&riscv->guest_x21,  buf, dir, size, mod); break;
+   case 22: VG_(transfer) (&riscv->guest_x22,  buf, dir, size, mod); break;
+   case 23: VG_(transfer) (&riscv->guest_x23,  buf, dir, size, mod); break;
+   case 24: VG_(transfer) (&riscv->guest_x24,  buf, dir, size, mod); break;
+   case 25: VG_(transfer) (&riscv->guest_x25,  buf, dir, size, mod); break;
+   case 26: VG_(transfer) (&riscv->guest_x26,  buf, dir, size, mod); break;
+   case 27: VG_(transfer) (&riscv->guest_x27,  buf, dir, size, mod); break;
+   case 28: VG_(transfer) (&riscv->guest_x28,  buf, dir, size, mod); break;
+   case 29: VG_(transfer) (&riscv->guest_x29,  buf, dir, size, mod); break;
+   case 30: VG_(transfer) (&riscv->guest_x30,  buf, dir, size, mod); break;
+   case 31: VG_(transfer) (&riscv->guest_x31,  buf, dir, size, mod); break;
+   case 32: VG_(transfer) (&riscv->guest_pc,   buf, dir, size, mod); break;
+
+   case 33: VG_(transfer) (&riscv->guest_f0,   buf, dir, size, mod); break;
+   case 34: VG_(transfer) (&riscv->guest_f1,   buf, dir, size, mod); break;
+   case 35: VG_(transfer) (&riscv->guest_f2,   buf, dir, size, mod); break;
+   case 36: VG_(transfer) (&riscv->guest_f3,   buf, dir, size, mod); break;
+   case 37: VG_(transfer) (&riscv->guest_f4,   buf, dir, size, mod); break;
+   case 38: VG_(transfer) (&riscv->guest_f5,   buf, dir, size, mod); break;
+   case 39: VG_(transfer) (&riscv->guest_f6,   buf, dir, size, mod); break;
+   case 40: VG_(transfer) (&riscv->guest_f7,   buf, dir, size, mod); break;
+   case 41: VG_(transfer) (&riscv->guest_f8,   buf, dir, size, mod); break;
+   case 42: VG_(transfer) (&riscv->guest_f9,   buf, dir, size, mod); break;
+   case 43: VG_(transfer) (&riscv->guest_f10,  buf, dir, size, mod); break;
+   case 44: VG_(transfer) (&riscv->guest_f11,  buf, dir, size, mod); break;
+   case 45: VG_(transfer) (&riscv->guest_f12,  buf, dir, size, mod); break;
+   case 46: VG_(transfer) (&riscv->guest_f13,  buf, dir, size, mod); break;
+   case 47: VG_(transfer) (&riscv->guest_f14,  buf, dir, size, mod); break;
+   case 48: VG_(transfer) (&riscv->guest_f15,  buf, dir, size, mod); break;
+   case 49: VG_(transfer) (&riscv->guest_f16,  buf, dir, size, mod); break;
+   case 50: VG_(transfer) (&riscv->guest_f17,  buf, dir, size, mod); break;
+   case 51: VG_(transfer) (&riscv->guest_f18,  buf, dir, size, mod); break;
+   case 52: VG_(transfer) (&riscv->guest_f19,  buf, dir, size, mod); break;
+   case 53: VG_(transfer) (&riscv->guest_f20,  buf, dir, size, mod); break;
+   case 54: VG_(transfer) (&riscv->guest_f21,  buf, dir, size, mod); break;
+   case 55: VG_(transfer) (&riscv->guest_f22,  buf, dir, size, mod); break;
+   case 56: VG_(transfer) (&riscv->guest_f23,  buf, dir, size, mod); break;
+   case 57: VG_(transfer) (&riscv->guest_f24,  buf, dir, size, mod); break;
+   case 58: VG_(transfer) (&riscv->guest_f25,  buf, dir, size, mod); break;
+   case 59: VG_(transfer) (&riscv->guest_f26,  buf, dir, size, mod); break;
+   case 60: VG_(transfer) (&riscv->guest_f27,  buf, dir, size, mod); break;
+   case 61: VG_(transfer) (&riscv->guest_f28,  buf, dir, size, mod); break;
+   case 62: VG_(transfer) (&riscv->guest_f29,  buf, dir, size, mod); break;
+   case 63: VG_(transfer) (&riscv->guest_f30,  buf, dir, size, mod); break;
+   case 64: VG_(transfer) (&riscv->guest_f31,  buf, dir, size, mod); break;
+
+   case 65: break;
+
+   case 66: /* fflags = fcsr & 0x1F */
+        p = &riscv->guest_fcsr;
+        if (dir == valgrind_to_gdbserver)
+            v = *p & 0x1F;
+        VG_(transfer) (&v, buf, dir, size, mod);
+        if (dir == gdbserver_to_valgrind)
+            *p = (*p & ~0x1F) | v;
+        break;
+
+   case 67: /* frm = (fcsr & 0xE0) >> 5 */
+        p = &riscv->guest_fcsr;
+        if (dir == valgrind_to_gdbserver)
+            v = (*p & 0xE0) >> 5;
+        VG_(transfer) (&v, buf, dir, size, mod);
+        if (dir == gdbserver_to_valgrind)
+            *p = (*p & ~0xE0) | (v << 5);
+        break;
+
+   case 68: VG_(transfer) (&riscv->guest_fcsr, buf, dir, size, mod); break;
+   default: vg_assert(0);
+   }
+}
+
+static
+const char* target_xml (Bool shadow_mode)
+{
+   if (shadow_mode) {
+      return "riscv64-linux-valgrind.xml";
+   } else {
+      return "riscv64-linux.xml";
+   }
+}
+
+static CORE_ADDR** target_get_dtv (ThreadState *tst)
+{
+   VexGuestRISCV64State* riscv = (VexGuestRISCV64State*)&tst->arch.vex;
+
+   /* RISC-V uses Variant I as described by the ELF TLS specification,
+      with tp containing the address one past the end of the TCB.
+
+      from GLIBC sysdeps/riscv/nptl/tls.h, tp is just after tcbhead_t
+        typedef struct {
+            dtv_t *dtv;
+            void *private;
+        } tcbhead_t;
+   */
+   return (CORE_ADDR**)(void *)(riscv->guest_x4 - 2 * sizeof(void *));
+}
+
+static struct valgrind_target_ops low_target = {
+   num_regs,
+   regs,
+   2, //SP
+   transfer_register,
+   get_pc,
+   set_pc,
+   "riscv64",
+   target_xml,
+   target_get_dtv
+};
+
+void riscv64_init_architecture (struct valgrind_target_ops *target)
+{
+   *target = low_target;
+   set_register_cache (regs, num_regs);
+   gdbserver_expedite_regs = expedite_regs;
+}

--- a/coregrind/m_gdbserver/valgrind_low.h
+++ b/coregrind/m_gdbserver/valgrind_low.h
@@ -108,5 +108,6 @@ extern void s390x_init_architecture (struct valgrind_target_ops *target);
 extern void mips32_init_architecture (struct valgrind_target_ops *target);
 extern void mips64_init_architecture (struct valgrind_target_ops *target);
 extern void nanomips_init_architecture (struct valgrind_target_ops *target);
+extern void riscv64_init_architecture (struct valgrind_target_ops *target);
 
 #endif

--- a/coregrind/m_syswrap/syswrap-riscv64-linux.c
+++ b/coregrind/m_syswrap/syswrap-riscv64-linux.c
@@ -372,6 +372,7 @@ static SyscallTableEntry syscall_main_table[] = {
    LINXY(__NR_clock_nanosleep, sys_clock_nanosleep),       /* 115 */
    LINXY(__NR_syslog, sys_syslog),                         /* 116 */
    PLAXY(__NR_ptrace, sys_ptrace),                         /* 117 */
+   LINX_(__NR_sched_setaffinity, sys_sched_setaffinity),   /* 122 */
    LINX_(__NR_sched_yield, sys_sched_yield),               /* 124 */
    GENX_(__NR_kill, sys_kill),                             /* 129 */
    LINX_(__NR_tgkill, sys_tgkill),                         /* 131 */

--- a/coregrind/vgdb-invoker-ptrace.c
+++ b/coregrind/vgdb-invoker-ptrace.c
@@ -41,7 +41,6 @@
 #include <sys/wait.h>
 
 #if defined(VGA_riscv64)
-/* TODO */
 /* Glibc on riscv64 does not provide a definition of user or user_regs_struct
    in sys/user.h. Instead the definition of user_regs_struct is provided by the
    kernel in asm/ptrace.h. Pull it and then define the expected user
@@ -61,10 +60,10 @@ struct user {
 // So, better do not use PTRACE_GET/SETREGSET
 // Rather we use PTRACE_GETREGS or PTRACE_PEEKUSER.
 
-// The only platform on which we must use PTRACE_GETREGSET is arm64.
+// The only platform on which we must use PTRACE_GETREGSET is here.
 // The resulting vgdb cannot work in a bi-arch setup.
 // -1 means we will check that PTRACE_GETREGSET works.
-#  if defined(VGA_arm64)
+#  if defined(VGA_arm64) || defined(VGA_riscv64)
 #define USE_PTRACE_GETREGSET
 #  endif
 #endif
@@ -887,7 +886,7 @@ Bool invoker_invoke_gdbserver (pid_t pid)
 #elif defined(VGA_mips64)
    sp = user_mod.regs[29];
 #elif defined(VGA_riscv64)
-   assert(0);
+   sp = user_mod.regs.sp;
 #else
    I_die_here : (sp) architecture missing in vgdb-invoker-ptrace.c
 #endif
@@ -1087,7 +1086,9 @@ Bool invoker_invoke_gdbserver (pid_t pid)
       user_mod.regs[34] = shared64->invoke_gdbserver;
       user_mod.regs[25] = shared64->invoke_gdbserver;
 #elif defined(VGA_riscv64)
-      assert(0);
+      user_mod.regs.a0 = check;
+      user_mod.regs.ra = bad_return;
+      user_mod.regs.pc = shared64->invoke_gdbserver;
 #else
       I_die_here: architecture missing in vgdb-invoker-ptrace.c
 #endif

--- a/include/vki/vki-scnums-riscv64-linux.h
+++ b/include/vki/vki-scnums-riscv64-linux.h
@@ -85,6 +85,7 @@
 #define __NR_clock_nanosleep 115
 #define __NR_syslog 116
 #define __NR_ptrace 117
+#define __NR_sched_setaffinity 122
 #define __NR_sched_yield 124
 #define __NR_kill 129
 #define __NR_tkill 130


### PR DESCRIPTION
@Xeonacid and me cooperated out these patches. The 1st one add gdbserver support. Main dataset came from most recently GDB source and shadow registers xml also based on them.

The 2nd one fixed some code to let gdbserver_tests passed.
- Add 'ebreak' IR. There is a 'ebreak' instruction after `jal __libc_start_main` in RISC-V binary . Some tests need vgdb to decode it otherwise would failed.
- Add 'sched_setaffinity' syscall. Test program sleepers.c needs it to work.
- Add gdb output filter for hginfo.vgtest. In gdb 10.3.1, gdb output additional information compared with the expected result.
- Eliminate 'static' of TLS storage in tls.c. It seems that GCC doesn't support DW_OP_GNU_push_tls_address for RISC-V, and always optimized out 'static __thread' variable address. This behavior does not affect program running, but when debug try to acquire its address, `Can't take address of "local" which isn't an lvalue.`

With these patches, all 25 gdbserver_tests get passed.