### PR TITLE
Riscv64 linux memchecktest

### DIFF
--- a/memcheck/tests/atomic_incs.c
+++ b/memcheck/tests/atomic_incs.c
@@ -246,8 +246,25 @@ __attribute__((noinline)) void atomic_add_8bit ( char* p, int n )
    } while (block[2] != 1);
 #endif
 #elif defined(VGA_riscv64)
-   /* TODO Implement. */
-   assert(0);
+   unsigned long long int block[3]
+      = { (unsigned long long int)p, (unsigned long long int)n,
+          0xFFFFFFFFFFFFFFFFULL};
+   do {
+      __asm__ __volatile__(
+         "mv     t0, %0"         "\n\t"
+         "ld     t1, (t0)"       "\n\t" // p
+         "ld     t2, 8(t0)"      "\n\t" // n
+         "lr.w   t3, (t1)"       "\n\t"
+         "slli   t3, t3, 56"     "\n\t" // signed-extend
+         "sra    t3, t3, 56"     "\n\t"
+         "add    t3, t3, t2"     "\n\t"
+         "sc.w   t4, t3, (t1)"   "\n\t"
+         "sd     t4, 16(t0)"     "\n\t"
+         : /*out*/
+         : /*in*/ "r"(&block[0])
+         : /*trash*/ "memory", "cc", "t0", "t1", "t2", "t3", "t4"
+      );
+   } while (block[2] != 0);
 #else
 # error "Unsupported arch"
 #endif
@@ -465,8 +482,25 @@ __attribute__((noinline)) void atomic_add_16bit ( short* p, int n )
    } while (block[2] != 1);
 #endif
 #elif defined(VGA_riscv64)
-   /* TODO Implement. */
-   assert(0);
+   unsigned long long int block[3]
+   = { (unsigned long long int)p, (unsigned long long int)n,
+       0xFFFFFFFFFFFFFFFFULL};
+   do {
+      __asm__ __volatile__(
+         "mv     t0, %0"         "\n\t"
+         "ld     t1, (t0)"       "\n\t" // p
+         "ld     t2, 8(t0)"      "\n\t" // n
+         "lr.w   t3, (t1)"       "\n\t"
+         "slli   t3, t3, 48"     "\n\t" // signed-extend
+         "sra    t3, t3, 48"     "\n\t"
+         "add    t3, t3, t2"     "\n\t"
+         "sc.w   t4, t3, (t1)"   "\n\t"
+         "sd     t4, 16(t0)"     "\n\t"
+         : /*out*/
+         : /*in*/ "r"(&block[0])
+         : /*trash*/ "memory", "cc", "t0", "t1", "t2", "t3", "t4"
+      );
+   } while (block[2] != 0);
 #else
 # error "Unsupported arch"
 #endif
@@ -623,8 +657,23 @@ __attribute__((noinline)) void atomic_add_32bit ( int* p, int n )
       );
    } while (block[2] != 1);
 #elif defined(VGA_riscv64)
-   /* TODO Implement. */
-   assert(0);
+   unsigned long long int block[3]
+   = { (unsigned long long int)p, (unsigned long long int)n,
+       0xFFFFFFFFFFFFFFFFULL};
+   do {
+      __asm__ __volatile__(
+         "mv     t0, %0"         "\n\t"
+         "ld     t1, (t0)"       "\n\t" // p
+         "ld     t2, 8(t0)"      "\n\t" // n
+         "lr.w   t3, (t1)"       "\n\t"
+         "add    t3, t3, t2"     "\n\t"
+         "sc.w   t4, t3, (t1)"   "\n\t"
+         "sd     t4, 16(t0)"     "\n\t"
+         : /*out*/
+         : /*in*/ "r"(&block[0])
+         : /*trash*/ "memory", "cc", "t0", "t1", "t2", "t3", "t4"
+      );
+   } while (block[2] != 0);
 #else
 # error "Unsupported arch"
 #endif
@@ -728,8 +777,23 @@ __attribute__((noinline)) void atomic_add_64bit ( long long int* p, int n )
       );
    } while (block[2] != 1);
 #elif defined(VGA_riscv64)
-   /* TODO Implement. */
-   assert(0);
+   unsigned long long int block[3]
+   = { (unsigned long long int)p, (unsigned long long int)n,
+       0xFFFFFFFFFFFFFFFFULL};
+   do {
+      __asm__ __volatile__(
+         "mv     t0, %0"         "\n\t"
+         "ld     t1, (t0)"       "\n\t" // p
+         "ld     t2, 8(t0)"      "\n\t" // n
+         "lr.d   t3, (t1)"       "\n\t"
+         "add    t3, t3, t2"     "\n\t"
+         "sc.d   t4, t3, (t1)"   "\n\t"
+         "sd     t4, 16(t0)"     "\n\t"
+         : /*out*/
+         : /*in*/ "r"(&block[0])
+         : /*trash*/ "memory", "cc", "t0", "t1", "t2", "t3", "t4"
+      );
+   } while (block[2] != 0);
 #else
 # error "Unsupported arch"
 #endif
@@ -743,7 +807,7 @@ __attribute__((noinline)) void atomic_add_128bit ( MyU128* p,
     || defined(VGA_amd64) \
     || defined(VGA_ppc64be) || defined(VGA_ppc64le) \
     || defined(VGA_arm) \
-    || defined(VGA_s390x)
+    || defined(VGA_s390x) || defined(VGA_riscv64)
    /* do nothing; is not supported */
 #elif defined(VGA_arm64)
    unsigned long long int block[3]
@@ -764,9 +828,6 @@ __attribute__((noinline)) void atomic_add_128bit ( MyU128* p,
          : /*trash*/ "memory", "cc", "x5", "x7", "x8", "x9", "x10", "x4"
       );
    } while (block[2] != 0);
-#elif defined(VGA_riscv64)
-   /* TODO Implement. */
-   assert(0);
 #else
 # error "Unsupported arch"
 #endif

--- a/memcheck/tests/leak-segv-jmp.stderr.exp
+++ b/memcheck/tests/leak-segv-jmp.stderr.exp
@@ -14,8 +14,8 @@ To see them, rerun with: --leak-check=full --show-leak-kinds=all
 expecting a leak
 1,000 bytes in 1 blocks are definitely lost in loss record ... of ...
    at 0x........: malloc (vg_replace_malloc.c:...)
-   by 0x........: f (leak-segv-jmp.c:389)
-   by 0x........: main (leak-segv-jmp.c:464)
+   by 0x........: f (leak-segv-jmp.c:406)
+   by 0x........: main (leak-segv-jmp.c:481)
 
 LEAK SUMMARY:
    definitely lost: 1,000 bytes in 1 blocks
@@ -30,8 +30,8 @@ mprotect result 0
 expecting a leak again
 1,000 bytes in 1 blocks are definitely lost in loss record ... of ...
    at 0x........: malloc (vg_replace_malloc.c:...)
-   by 0x........: f (leak-segv-jmp.c:389)
-   by 0x........: main (leak-segv-jmp.c:464)
+   by 0x........: f (leak-segv-jmp.c:406)
+   by 0x........: main (leak-segv-jmp.c:481)
 
 LEAK SUMMARY:
    definitely lost: 1,000 bytes in 1 blocks
@@ -46,8 +46,8 @@ full mprotect result 0
 expecting a leak again after full mprotect
 1,000 bytes in 1 blocks are definitely lost in loss record ... of ...
    at 0x........: malloc (vg_replace_malloc.c:...)
-   by 0x........: f (leak-segv-jmp.c:389)
-   by 0x........: main (leak-segv-jmp.c:464)
+   by 0x........: f (leak-segv-jmp.c:406)
+   by 0x........: main (leak-segv-jmp.c:481)
 
 LEAK SUMMARY:
    definitely lost: 1,000 bytes in 1 blocks
@@ -62,13 +62,13 @@ mprotect result 0
 expecting heuristic not to crash after full mprotect
 1,000 bytes in 1 blocks are definitely lost in loss record ... of ...
    at 0x........: malloc (vg_replace_malloc.c:...)
-   by 0x........: f (leak-segv-jmp.c:389)
-   by 0x........: main (leak-segv-jmp.c:464)
+   by 0x........: f (leak-segv-jmp.c:406)
+   by 0x........: main (leak-segv-jmp.c:481)
 
 200,000 bytes in 1 blocks are possibly lost in loss record ... of ...
    at 0x........: calloc (vg_replace_malloc.c:...)
-   by 0x........: f (leak-segv-jmp.c:436)
-   by 0x........: main (leak-segv-jmp.c:464)
+   by 0x........: f (leak-segv-jmp.c:453)
+   by 0x........: main (leak-segv-jmp.c:481)
 
 LEAK SUMMARY:
    definitely lost: 1,000 bytes in 1 blocks


### PR DESCRIPTION
Hi, Petr. This patch fixes 2 memcheck test failures for riscv64.
(1) Update leak-segv-jmp.stderr.exp to match the new source.
(2) Add riscv64 load-reserved/store-conditional implementation in atomic_incs.c case.
Please help review this patch.