### PR TITLE
Add missing floating-point ITE/CSEL support in VEX backend

### DIFF
--- a/VEX/priv/host_riscv64_defs.h
+++ b/VEX/priv/host_riscv64_defs.h
@@ -336,6 +336,7 @@ typedef enum {
    RISCV64in_FpConvert,       /* Floating-point convert instruction. */
    RISCV64in_FpCompare,       /* Floating-point compare instruction. */
    RISCV64in_FpLdSt,          /* Floating-point load/store instruction. */
+   RISCV64in_FpCSEL,          /* Floating-point conditional-select pseudoinstruction.*/
    RISCV64in_CAS,             /* Compare-and-swap pseudoinstruction. */
    RISCV64in_FENCE,           /* Device I/O and memory fence. */
    RISCV64in_CSEL,            /* Conditional-select pseudoinstruction. */
@@ -455,6 +456,14 @@ typedef struct {
          HReg            base;
          Int             soff12; /* -2048 .. +2047 */
       } FpLdSt;
+      /* Floating-point conditional-select pseudoinstruction. */
+      struct {
+         IRType ty;
+         HReg   dst;
+         HReg   iftrue;
+         HReg   iffalse;
+         HReg   cond;
+      } FpCSEL;
       /* Compare-and-swap pseudoinstruction. */
       struct {
          RISCV64CASOp op;
@@ -552,6 +561,8 @@ RISCV64Instr*
 RISCV64Instr_FpCompare(RISCV64FpCompareOp op, HReg dst, HReg src1, HReg src2);
 RISCV64Instr*
 RISCV64Instr_FpLdSt(RISCV64FpLdStOp op, HReg reg, HReg base, Int soff12);
+RISCV64Instr*
+RISCV64Instr_FpCSEL(IRType ty, HReg dst, HReg iftrue, HReg iffalse, HReg cond);
 RISCV64Instr*
 RISCV64Instr_CAS(RISCV64CASOp op, HReg old, HReg addr, HReg expd, HReg data);
 RISCV64Instr* RISCV64Instr_FENCE(void);

--- a/VEX/priv/host_riscv64_isel.c
+++ b/VEX/priv/host_riscv64_isel.c
@@ -1551,6 +1551,19 @@ static HReg iselFltExpr_wrk(ISelEnv* env, IRExpr* e)
       return dst;
    }
 
+   /* ---------------------- MULTIPLEX ---------------------- */
+   case Iex_ITE: {
+      /* ITE(ccexpr, iftrue, iffalse) */
+      HReg   cond    = iselIntExpr_R(env, e->Iex.ITE.cond);
+      HReg   iftrue  = iselFltExpr(env, e->Iex.ITE.iftrue);
+      HReg   iffalse = iselFltExpr(env, e->Iex.ITE.iffalse);
+      HReg   dst     = newVRegF(env);
+      IRType csel_ty = typeOfIRExpr(env->type_env, e->Iex.ITE.iftrue);
+      vassert(csel_ty == Ity_F64 || csel_ty == Ity_F32);
+      addInstr(env, RISCV64Instr_FpCSEL(csel_ty, dst, iftrue, iffalse, cond));
+      return dst;
+   }
+
    default:
       break;
    }


### PR DESCRIPTION
Hi, Petr! This patch adds missing floating-point ITE/CSEL support in VEX backend.
During running a floating-point application, we found that the valgrind-riscv64 crashed in VEX backend iselFltExpr. By tracing the error back, we are sure that it is caused by a missing implementation of floating-point ITE expr. This patch adds the ITE and CSEL for Fp32/Fp64 which is similar to ARM64 VFCSel, except that we use IRType instead of isD flag to distinguish different ITE types for easily extending it to support Fp16 in the future.
Please help review this patch, THX.