### PR TITLE
support fence.i

### DIFF
--- a/README.riscv64
+++ b/README.riscv64
@@ -15,7 +15,7 @@ The following ISA base and extensions are currently supported:
 | RV64F        | Single-precision floating-point   |   30/30 | (3)      |
 | RV64D        | Double-precision floating-point   |   32/32 |          |
 | RV64Zicsr    | Control & status register         |     3/6 | (4), (5) |
-| RV64Zifencei | Instruction-fetch fence           |     0/1 | (6)      |
+| RV64Zifencei | Instruction-fetch fence           |     1/1 |          |
 | RV64C        | Compressed                        |   37/37 |          |
 
 Notes:
@@ -24,7 +24,6 @@ Notes:
 (3) Operations do not check if the input operands are correctly NaN-boxed.
 (4) CSRRWI, CSRRSI and CSRRCI are not recognized.
 (5) Only registers fflags, frm and fcsr are accepted.
-(6) FENCE.I is not recognized.
 
 
 Implementation tidying-up/TODO notes

--- a/VEX/priv/guest_riscv64_toIR.c
+++ b/VEX/priv/guest_riscv64_toIR.c
@@ -1611,10 +1611,11 @@ static Bool dis_RV64I(/*MB_OUT*/ DisResult* dres,
 
    /* ------------------------ fence ------------------------ */
    if (INSN(19, 0) == 0b00000000000000001111) {
-      UInt succ = INSN(23, 20);
-      UInt pred = INSN(27, 24);
-      UInt fm   = INSN(31, 28);
-      if (fm != 0b0000 && (fm != 0b1000 || succ != 0b0011 || pred != 0b0011)) {
+      UInt succ   = INSN(23, 20);
+      UInt pred   = INSN(27, 24);
+      UInt fm     = INSN(31, 28);
+      UInt funct3 = INSN(14, 12);
+      if (fm != 0b0000 && (fm != 0b1000 || succ != 0b0011 || pred != 0b0011) && funct3 != 0b001) {
          /* Invalid FENCE, fall through. */
       } else {
          stmt(irsb, IRStmt_MBE(Imbe_Fence));
@@ -1622,6 +1623,8 @@ static Bool dis_RV64I(/*MB_OUT*/ DisResult* dres,
             DIP("fence.tso\n");
          else if (pred == 0b1111 && succ == 0b1111)
             DIP("fence\n");
+         else if (funct3 == 0b001)
+            DIP("fence.i\n");
          else
             DIP("fence %s%s%s%s,%s%s%s%s\n", (pred & 0x8) ? "i" : "",
                 (pred & 0x4) ? "o" : "", (pred & 0x2) ? "r" : "",


### PR DESCRIPTION
#19 partially
sorry for the inconsistent commit log, should be:
`riscv64: Support fence.i`
The project-level README is left unmodified.