### PR TITLE
riscv64: Add support for mulhsu and CSRR*I instruction

### DIFF
--- a/README.riscv64
+++ b/README.riscv64
@@ -14,16 +14,15 @@ The following ISA base and extensions are currently supported:
 | RV64A        | Atomic                            |   22/22 | (1)      |
 | RV64F        | Single-precision floating-point   |   30/30 | (2)      |
 | RV64D        | Double-precision floating-point   |   32/32 |          |
-| RV64Zicsr    | Control & status register         |     3/6 | (3), (4) |
-| RV64Zifencei | Instruction-fetch fence           |     0/1 | (5)      |
+| RV64Zicsr    | Control & status register         |     6/6 | (3)      |
+| RV64Zifencei | Instruction-fetch fence           |     0/1 | (4)      |
 | RV64C        | Compressed                        |   37/37 |          |
 
 Notes:
 (1) LR and SC use the VEX "fallback" method which suffers from the ABA problem.
 (2) Operations do not check if the input operands are correctly NaN-boxed.
-(3) CSRRWI, CSRRSI and CSRRCI are not recognized.
-(4) Only registers fflags, frm and fcsr are accepted.
-(5) FENCE.I is not recognized.
+(3) Only registers fflags, frm and fcsr are accepted.
+(4) FENCE.I is not recognized.
 
 
 Implementation tidying-up/TODO notes

--- a/README.riscv64
+++ b/README.riscv64
@@ -10,21 +10,20 @@ The following ISA base and extensions are currently supported:
 | Name         | Description                       | #Instrs | Notes    |
 | ------------ | --------------------------------- | ------- | -------- |
 | RV64I        | Base instruction set              |   52/52 |          |
-| RV64M        | Integer multiplication & division |   12/13 | (1)      |
-| RV64A        | Atomic                            |   22/22 | (2)      |
-| RV64F        | Single-precision floating-point   |   30/30 | (3)      |
+| RV64M        | Integer multiplication & division |   13/13 |          |
+| RV64A        | Atomic                            |   22/22 | (1)      |
+| RV64F        | Single-precision floating-point   |   30/30 | (2)      |
 | RV64D        | Double-precision floating-point   |   32/32 |          |
-| RV64Zicsr    | Control & status register         |     3/6 | (4), (5) |
-| RV64Zifencei | Instruction-fetch fence           |     0/1 | (6)      |
+| RV64Zicsr    | Control & status register         |     3/6 | (3), (4) |
+| RV64Zifencei | Instruction-fetch fence           |     0/1 | (5)      |
 | RV64C        | Compressed                        |   37/37 |          |
 
 Notes:
-(1) MULHSU is not recognized.
-(2) LR and SC use the VEX "fallback" method which suffers from the ABA problem.
-(3) Operations do not check if the input operands are correctly NaN-boxed.
-(4) CSRRWI, CSRRSI and CSRRCI are not recognized.
-(5) Only registers fflags, frm and fcsr are accepted.
-(6) FENCE.I is not recognized.
+(1) LR and SC use the VEX "fallback" method which suffers from the ABA problem.
+(2) Operations do not check if the input operands are correctly NaN-boxed.
+(3) CSRRWI, CSRRSI and CSRRCI are not recognized.
+(4) Only registers fflags, frm and fcsr are accepted.
+(5) FENCE.I is not recognized.
 
 
 Implementation tidying-up/TODO notes

--- a/VEX/priv/guest_riscv64_toIR.c
+++ b/VEX/priv/guest_riscv64_toIR.c
@@ -1753,76 +1753,89 @@ static Bool dis_RV64M(/*MB_OUT*/ DisResult* dres,
       UInt funct3 = INSN(14, 12);
       UInt rs1    = INSN(19, 15);
       UInt rs2    = INSN(24, 20);
-      if (funct3 == 0b010) {
-         /* Invalid {MUL,DIV,REM}<x>, fall through. */
-      } else if (funct3 == 0b010) {
-         /* MULHSU, not currently handled, fall through. */
-      } else {
-         if (rd != 0) {
-            IRExpr* expr;
-            switch (funct3) {
-            case 0b000:
-               expr = binop(Iop_Mul64, getIReg64(rs1), getIReg64(rs2));
-               break;
-            case 0b001:
-               expr = unop(Iop_128HIto64,
-                           binop(Iop_MullS64, getIReg64(rs1), getIReg64(rs2)));
-               break;
-            case 0b011:
-               expr = unop(Iop_128HIto64,
-                           binop(Iop_MullU64, getIReg64(rs1), getIReg64(rs2)));
-               break;
-            case 0b100:
-               expr = binop(Iop_DivS64, getIReg64(rs1), getIReg64(rs2));
-               break;
-            case 0b101:
-               expr = binop(Iop_DivU64, getIReg64(rs1), getIReg64(rs2));
-               break;
-            case 0b110:
-               expr =
-                  unop(Iop_128HIto64, binop(Iop_DivModS64to64, getIReg64(rs1),
-                                            getIReg64(rs2)));
-               break;
-            case 0b111:
-               expr =
-                  unop(Iop_128HIto64, binop(Iop_DivModU64to64, getIReg64(rs1),
-                                            getIReg64(rs2)));
-               break;
-            default:
-               vassert(0);
-            }
-            putIReg64(irsb, rd, expr);
-         }
-         const HChar* name;
+      if (rd != 0) {
+         IRExpr* expr;
          switch (funct3) {
          case 0b000:
-            name = "mul";
+            expr = binop(Iop_Mul64, getIReg64(rs1), getIReg64(rs2));
             break;
          case 0b001:
-            name = "mulh";
+            expr = unop(Iop_128HIto64,
+                        binop(Iop_MullS64, getIReg64(rs1), getIReg64(rs2)));
+            break;
+         case 0b010:
+            /* Inspired by QEMU's mulhsu emulation.
+               mulhsu(rs1, rs2)
+               => ((s128)rs1 * (u128)rs2) >> 64
+               => mulhu(rs1, rs2) + mul(rs1 < 0 ? -1 : 0, rs2)
+               => mulhu(rs1, rs2) + (rs1 < 0 ? -rs2 : 0)
+               => mulhu(rs1, rs2) - (rs1 < 0 ? rs2 : 0)
+               => mulhu(rs1, rs2) - (srai(rs1, __riscv_xlen - 1) & rs2)
+             */
+            expr = unop(Iop_128HIto64,
+                        binop(Iop_MullU64, getIReg64(rs1), getIReg64(rs2)));
+            IRExpr* tmp = binop(Iop_And64,
+                                binop(Iop_Sar64, getIReg64(rs1), mkU8(63)),
+                                getIReg64(rs2));
+            expr = binop(Iop_Sub64, expr, tmp);
             break;
          case 0b011:
-            name = "mulhu";
+            expr = unop(Iop_128HIto64,
+                        binop(Iop_MullU64, getIReg64(rs1), getIReg64(rs2)));
             break;
          case 0b100:
-            name = "div";
+            expr = binop(Iop_DivS64, getIReg64(rs1), getIReg64(rs2));
             break;
          case 0b101:
-            name = "divu";
+            expr = binop(Iop_DivU64, getIReg64(rs1), getIReg64(rs2));
             break;
          case 0b110:
-            name = "rem";
+            expr =
+               unop(Iop_128HIto64, binop(Iop_DivModS64to64, getIReg64(rs1),
+                                         getIReg64(rs2)));
             break;
          case 0b111:
-            name = "remu";
+            expr =
+               unop(Iop_128HIto64, binop(Iop_DivModU64to64, getIReg64(rs1),
+                                         getIReg64(rs2)));
             break;
          default:
             vassert(0);
          }
-         DIP("%s %s, %s, %s\n", name, nameIReg(rd), nameIReg(rs1),
-             nameIReg(rs2));
-         return True;
+         putIReg64(irsb, rd, expr);
       }
+      const HChar* name;
+      switch (funct3) {
+      case 0b000:
+         name = "mul";
+         break;
+      case 0b001:
+         name = "mulh";
+         break;
+      case 0b010:
+         name = "mulhsu";
+         break;
+      case 0b011:
+         name = "mulhu";
+         break;
+      case 0b100:
+         name = "div";
+         break;
+      case 0b101:
+         name = "divu";
+         break;
+      case 0b110:
+         name = "rem";
+         break;
+      case 0b111:
+         name = "remu";
+         break;
+      default:
+         vassert(0);
+      }
+      DIP("%s %s, %s, %s\n", name, nameIReg(rd), nameIReg(rs1),
+          nameIReg(rs2));
+      return True;
    }
 
    /* ------------------ mulw rd, rs1, rs2 ------------------ */

--- a/none/tests/riscv64/csr.c
+++ b/none/tests/riscv64/csr.c
@@ -111,13 +111,82 @@ static void test_csr64_shared(void)
    TESTINST_1_1_CSR(4, "csrrc a0, fcsr, zero", 0xff, 0x00, a0, fcsr, zero);
 
    /* -------------- csrrwi rd, csr, uimm[4:0] -------------- */
-   /* Not currently handled. */
+   /* fflags */
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fflags, 0x01", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fflags, 0x1f", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fflags, 0x1e", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fflags, 0x00", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi t5, fflags, 0x01", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi zero, fflags, 0x01", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fflags, 0x00", 0xff, a0, fcsr);
+
+   /* frm */
+   TESTINST_1_1_CSRI(4, "csrrwi a0, frm, 0x1", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, frm, 0x7", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, frm, 0x6", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, frm, 0x0", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi t5, frm, 0x1", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi zero, frm, 0x1", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, frm, 0x0", 0xff, a0, fcsr);
+
+   /* fcsr */
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fcsr, 0x01", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fcsr, 0x00", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi t5, fcsr, 0x01", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi zero, fcsr, 0x01", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrwi a0, fcsr, 0x00", 0xff, a0, fcsr);
 
    /* -------------- csrrsi rd, csr, uimm[4:0] -------------- */
-   /* Not currently handled. */
+   /* fflags */
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fflags, 0x01", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fflags, 0x1f", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fflags, 0x1e", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fflags, 0x00", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi t5, fflags, 0x01", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi zero, fflags, 0x01", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fflags, 0x00", 0xff, a0, fcsr);
+
+   /* frm */
+   TESTINST_1_1_CSRI(4, "csrrsi a0, frm, 0x1", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, frm, 0x7", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, frm, 0x6", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, frm, 0x0", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi t5, frm, 0x1", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi zero, frm, 0x1", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, frm, 0x0", 0xff, a0, fcsr);
+
+   /* fcsr */
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fcsr, 0x01", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fcsr, 0x00", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi t5, fcsr, 0x01", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi zero, fcsr, 0x01", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrsi a0, fcsr, 0x00", 0xff, a0, fcsr);
 
    /* -------------- csrrci rd, csr, uimm[4:0] -------------- */
-   /* Not currently handled. */
+   /* fflags */
+   TESTINST_1_1_CSRI(4, "csrrci a0, fflags, 0x01", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, fflags, 0x1f", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, fflags, 0x1e", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, fflags, 0x00", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci t5, fflags, 0x01", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci zero, fflags, 0x01", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, fflags, 0x00", 0xff, a0, fcsr);
+
+   /* frm */
+   TESTINST_1_1_CSRI(4, "csrrci a0, frm, 0x1", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, frm, 0x7", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, frm, 0x6", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, frm, 0x0", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci t5, frm, 0x1", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci zero, frm, 0x1", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, frm, 0x0", 0xff, a0, fcsr);
+
+   /* fcsr */
+   TESTINST_1_1_CSRI(4, "csrrci a0, fcsr, 0x01", 0x00, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, fcsr, 0x00", 0xff, a0, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci t5, fcsr, 0x01", 0x00, t5, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci zero, fcsr, 0x01", 0xff, zero, fcsr);
+   TESTINST_1_1_CSRI(4, "csrrci a0, fcsr, 0x00", 0xff, a0, fcsr);
 }
 
 int main(void)

--- a/none/tests/riscv64/csr.stdout.exp
+++ b/none/tests/riscv64/csr.stdout.exp
@@ -215,3 +215,174 @@ csrrc zero, fcsr, a1 ::
 csrrc a0, fcsr, zero ::
   inputs: zero=0x0000000000000000, fcsr=0x00000000000000ff
   output: a0=0x00000000000000ff, fcsr=0x00000000000000ff
+csrrwi a0, fflags, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000001
+csrrwi a0, fflags, 0x1f ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x000000000000001f
+csrrwi a0, fflags, 0x1e ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000fe
+csrrwi a0, fflags, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000e0
+csrrwi t5, fflags, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000001
+csrrwi zero, fflags, 0x01 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000e1
+csrrwi a0, fflags, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000e0
+csrrwi a0, frm, 0x1 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000020
+csrrwi a0, frm, 0x7 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x00000000000000e0
+csrrwi a0, frm, 0x6 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x00000000000000df
+csrrwi a0, frm, 0x0 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x000000000000001f
+csrrwi t5, frm, 0x1 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000020
+csrrwi zero, frm, 0x1 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x000000000000003f
+csrrwi a0, frm, 0x0 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x000000000000001f
+csrrwi a0, fcsr, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000001
+csrrwi a0, fcsr, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x00000000000000ff, fcsr=0x0000000000000000
+csrrwi t5, fcsr, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000001
+csrrwi zero, fcsr, 0x01 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x0000000000000001
+csrrwi a0, fcsr, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x00000000000000ff, fcsr=0x0000000000000000
+csrrsi a0, fflags, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000001
+csrrsi a0, fflags, 0x1f ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x000000000000001f
+csrrsi a0, fflags, 0x1e ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000ff
+csrrsi a0, fflags, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000ff
+csrrsi t5, fflags, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000001
+csrrsi zero, fflags, 0x01 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000ff
+csrrsi a0, fflags, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000ff
+csrrsi a0, frm, 0x1 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000020
+csrrsi a0, frm, 0x7 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x00000000000000e0
+csrrsi a0, frm, 0x6 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x00000000000000ff
+csrrsi a0, frm, 0x0 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x00000000000000ff
+csrrsi t5, frm, 0x1 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000020
+csrrsi zero, frm, 0x1 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000ff
+csrrsi a0, frm, 0x0 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x00000000000000ff
+csrrsi a0, fcsr, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000001
+csrrsi a0, fcsr, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x00000000000000ff, fcsr=0x00000000000000ff
+csrrsi t5, fcsr, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000001
+csrrsi zero, fcsr, 0x01 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000ff
+csrrsi a0, fcsr, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x00000000000000ff, fcsr=0x00000000000000ff
+csrrci a0, fflags, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000000
+csrrci a0, fflags, 0x1f ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000000
+csrrci a0, fflags, 0x1e ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000e1
+csrrci a0, fflags, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000ff
+csrrci t5, fflags, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000000
+csrrci zero, fflags, 0x01 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000fe
+csrrci a0, fflags, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x000000000000001f, fcsr=0x00000000000000ff
+csrrci a0, frm, 0x1 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000000
+csrrci a0, frm, 0x7 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000000
+csrrci a0, frm, 0x6 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x000000000000003f
+csrrci a0, frm, 0x0 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x00000000000000ff
+csrrci t5, frm, 0x1 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000000
+csrrci zero, frm, 0x1 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000df
+csrrci a0, frm, 0x0 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x0000000000000007, fcsr=0x00000000000000ff
+csrrci a0, fcsr, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: a0=0x0000000000000000, fcsr=0x0000000000000000
+csrrci a0, fcsr, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x00000000000000ff, fcsr=0x00000000000000ff
+csrrci t5, fcsr, 0x01 ::
+  inputs: fcsr=0x0000000000000000
+  output: t5=0x0000000000000000, fcsr=0x0000000000000000
+csrrci zero, fcsr, 0x01 ::
+  inputs: fcsr=0x00000000000000ff
+  output: zero=0x0000000000000000, fcsr=0x00000000000000fe
+csrrci a0, fcsr, 0x00 ::
+  inputs: fcsr=0x00000000000000ff
+  output: a0=0x00000000000000ff, fcsr=0x00000000000000ff

--- a/none/tests/riscv64/muldiv.c
+++ b/none/tests/riscv64/muldiv.c
@@ -63,7 +63,31 @@ static void test_muldiv_shared(void)
                 zero, a0, a1);
 
    /* ----------------- mulhsu rd, rs1, rs2 ----------------- */
-   /* Not currently handled. */
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x0000000000005000, 0x0000000000002000,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x7fffffffffffffff, 0x0000000000000002,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x7fffffffffffffff, 0x7fffffffffffffff,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x7fffffffffffffff, 0xffffffffffffffff,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0xffffffffffffffff, 0xffffffffffffffff,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x8000000000000000, 0x0000000000000002,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x8000000000000000, 0xffffffffffffffff,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x8000000000000000, 0x8000000000000000,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0x0000000000000001, 0x0000000000000000,
+                a0, a1, a2);
+   TESTINST_1_2(4, "mulhsu a0, a1, a2", 0xffffffffffffffff, 0x0000000000000000,
+                a0, a1, a2);
+
+   TESTINST_1_2(4, "mulhsu t4, t5, t6", 0x0000000000001000, 0x0000000000002000,
+                t4, t5, t6);
+   TESTINST_1_2(4, "mulhsu zero, a0, a1", 0x0000000000001000, 0x0000000000002000,
+                zero, a0, a1);
 
    /* ----------------- mulhu rd, rs1, rs2 ------------------ */
    TESTINST_1_2(4, "mulhu a0, a1, a2", 0x0000000000005000, 0x0000000000002000,

--- a/none/tests/riscv64/muldiv.stdout.exp
+++ b/none/tests/riscv64/muldiv.stdout.exp
@@ -71,6 +71,42 @@ mulh t4, t5, t6 ::
 mulh zero, a0, a1 ::
   inputs: a0=0x0000000000001000, a1=0x0000000000002000
   output: zero=0x0000000000000000
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x0000000000005000, a2=0x0000000000002000
+  output: a0=0x0000000000000000
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x7fffffffffffffff, a2=0x0000000000000002
+  output: a0=0x0000000000000000
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x7fffffffffffffff, a2=0x7fffffffffffffff
+  output: a0=0x3fffffffffffffff
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x7fffffffffffffff, a2=0xffffffffffffffff
+  output: a0=0x7ffffffffffffffe
+mulhsu a0, a1, a2 ::
+  inputs: a1=0xffffffffffffffff, a2=0xffffffffffffffff
+  output: a0=0xffffffffffffffff
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x8000000000000000, a2=0x0000000000000002
+  output: a0=0xffffffffffffffff
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x8000000000000000, a2=0xffffffffffffffff
+  output: a0=0x8000000000000000
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x8000000000000000, a2=0x8000000000000000
+  output: a0=0xc000000000000000
+mulhsu a0, a1, a2 ::
+  inputs: a1=0x0000000000000001, a2=0x0000000000000000
+  output: a0=0x0000000000000000
+mulhsu a0, a1, a2 ::
+  inputs: a1=0xffffffffffffffff, a2=0x0000000000000000
+  output: a0=0x0000000000000000
+mulhsu t4, t5, t6 ::
+  inputs: t5=0x0000000000001000, t6=0x0000000000002000
+  output: t4=0x0000000000000000
+mulhsu zero, a0, a1 ::
+  inputs: a0=0x0000000000001000, a1=0x0000000000002000
+  output: zero=0x0000000000000000
 mulhu a0, a1, a2 ::
   inputs: a1=0x0000000000005000, a2=0x0000000000002000
   output: a0=0x0000000000000000


### PR DESCRIPTION
The first patch adds support for the mulhsu instruction from M-ext.
The second patch adds support for CSRRWI, CSRRSI and CSRRCI instructions from Zicsr extension.
Update the README.riscv64 accordingly.

BRs,
Xiao
