### PR TITLE
riscv64: Fix link error about relocation

### DIFF
--- a/none/tests/riscv64/testinst.h
+++ b/none/tests/riscv64/testinst.h
@@ -403,11 +403,11 @@ static void show_block_diff(unsigned char* block1,
          ".endif;"                                                             \
          ".if \"" #rs1 "\" != \"unused\";"                                     \
          "sd " #rs1 ", 48(%[w]);"      /* Spill rs1. */                        \
-         "la " #rs1 ", " rs1_val ";"   /* Load the first input. */             \
+         "lla " #rs1 ", " rs1_val ";"  /* Load the first input. */             \
          ".endif;"                                                             \
          ".if \"" #rs2 "\" != \"unused\";"                                     \
          "sd " #rs2 ", 56(%[w]);"      /* Spill rs2. */                        \
-         "la " #rs2 ", " rs2_val ";"   /* Load the second input. */            \
+         "lla " #rs2 ", " rs2_val ";"  /* Load the second input. */            \
          ".endif;"                                                             \
          "j 1f;"                                                               \
          ".option push;"                                                       \


### PR DESCRIPTION
With GNU ld v2.42, the integer.c and compressed.c build fail with error: "dangerous relocation: The addend isn't allowed for R_RISCV_GOT_HI20" for JMP_RANGE related test cases.

This patch changes the target addr loading to local addr loading, thus to avoid the unnecessary global symbol relocation.

Though currently there's no "1f+x" style addr loading for rs2, this patch changes it together with rs1.